### PR TITLE
Add search parameter to /customers end point and Removed /customers/search endpoint

### DIFF
--- a/backend/app/Http/Controllers/CustomerController.php
+++ b/backend/app/Http/Controllers/CustomerController.php
@@ -15,48 +15,58 @@ class CustomerController extends Controller
         $this->customerService = $customerService;
     }
 
-    public function getAllCustomers()
+    public function getAllCustomers(Request $request)
     {
-      return response()->json($this->customerService->getAllCustomers());
+        $name = $request->input('name');
+        $email = $request->input('email');
+
+        if ($name || $email) {
+            $results = $this->customerService->searchCustomers($name, $email);
+        } else {
+            $results = $this->customerService->getAllCustomers();
+        }
+
+        return response()->json($results);
+        //return response()->json($this->customerService->getAllCustomers());
     }
 
-    public function searchCustomer(Request $request)
-    {
-      $term = $request->input('query');
-      $results = $this->customerService->searchCustomers($term);
-      return response()->json($results);
-    }
+    // public function searchCustomer(Request $request)
+    // {
+    //     $term = $request->input('query');
+    //     $results = $this->customerService->searchCustomers($term);
+    //     return response()->json($results);
+    // }
 
     public function showCustomer($id){
-      return response()->json($this->customerService->getCustomer($id));
+        return response()->json($this->customerService->getCustomer($id));
     }
 
     public function createCustomer(Request $request)
     {
-      $validated = $request->validate([
-        'first_name' => 'required|string|max:255',
-        'last_name' => 'required|string|max:255',
-        'email' => 'required|email|unique:customers,email',
-        'contact_number' => 'nullable|string|max:20',
-      ]);
+        $validated = $request->validate([
+            'first_name' => 'required|string|max:255',
+            'last_name' => 'required|string|max:255',
+            'email' => 'required|email|unique:customers,email',
+            'contact_number' => 'nullable|string|max:20',
+        ]);
 
-      return response()->json($this->customerService->createCustomer($validated));
+        return response()->json($this->customerService->createCustomer($validated));
     }
 
     public function updateCustomer(Request $request, $id)
     {
-      $validated = $request->validate([
-        'first_name' => 'sometimes|required|string|max:255',
-        'last_name' => 'sometimes|required|string|max:255',
-        'email' => 'sometimes|required|email|unique:customers,email,' . $id . ',customer_id',
-        'contact_number' => 'nullable|string|max:20',
-      ]);
+        $validated = $request->validate([
+            'first_name' => 'sometimes|required|string|max:255',
+            'last_name' => 'sometimes|required|string|max:255',
+            'email' => 'sometimes|required|email|unique:customers,email,' . $id . ',customer_id',
+            'contact_number' => 'nullable|string|max:20',
+        ]);
 
-      return response()->json($this->customerService->updateCustomer($id, $validated));
+        return response()->json($this->customerService->updateCustomer($id, $validated));
     }
 
     public function deleteCustomer($id)
     {
-      return response()->json($this->customerService->deleteCustomer($id));
+        return response()->json($this->customerService->deleteCustomer($id));
     }
 }

--- a/backend/app/Services/CustomerService.php
+++ b/backend/app/Services/CustomerService.php
@@ -16,6 +16,11 @@ class CustomerService
     $this->elasticsearchService = $elasticsearchService;
   }
 
+    public function getAllCustomers()
+    {
+        return Customer::all();
+    }
+
     public function searchCustomers(string $name = null, string $email = null)
     {
         $must = [];

--- a/backend/app/Services/CustomerService.php
+++ b/backend/app/Services/CustomerService.php
@@ -16,25 +16,56 @@ class CustomerService
     $this->elasticsearchService = $elasticsearchService;
   }
 
-    public function getAllCustomers()
+    public function searchCustomers(string $name = null, string $email = null)
     {
-        return Customer::all();
-    }
-
-    public function searchCustomers(string $term)
-    {
+        $must = [];
+    
+        // If name is provided, search in first_name and last_name
+        if ($name) {
+            $must[] = [
+                'multi_match' => [
+                    'query' => $name,
+                    'fields' => ['first_name', 'last_name'],
+                    'operator' => 'and',
+                    'fuzziness' => 'AUTO'
+                ]
+            ];
+        }
+        
+        // If email is provided, search in email field
+        if ($email) {
+            $must[] = [
+                'wildcard' => [
+                    'email' => "*{$email}*"
+                ]
+            ];
+        }
+        
         $query = [
-            'multi_match' => [
-            'query' => $term,
-            'fields' => ['first_name', 'last_name', 'email', 'contact_number']
+            'bool' => [
+                'must' => $must
             ]
         ];
-
+        
         $response = $this->elasticsearchService->search('customers', $query);
         $hits = $response['hits']['hits'] ?? [];
-
         return array_map(fn($hit) => $hit['_source'], $hits);
     }
+
+    // public function searchCustomers(string $term)
+    // {
+    //     $query = [
+    //         'multi_match' => [
+    //         'query' => $term,
+    //         'fields' => ['first_name', 'last_name', 'email', 'contact_number']
+    //         ]
+    //     ];
+
+    //     $response = $this->elasticsearchService->search('customers', $query);
+    //     $hits = $response['hits']['hits'] ?? [];
+
+    //     return array_map(fn($hit) => $hit['_source'], $hits);
+    // }
 
     public function getCustomer(int $id)
     {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,7 +5,7 @@ use App\Services\ElasticsearchService;
 
 Route::get('/customers', [CustomerController::class, 'getAllCustomers']);
 
-Route::get('/customers/search', [CustomerController::class, 'searchCustomer']);
+//Route::get('/customers/search', [CustomerController::class, 'searchCustomer']);
 
 Route::get('/customers/{id}', [CustomerController::class, 'showCustomer']);
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-name: crmapp-v2.0.2
+name: crmapp-v3
 
 services:
   api:


### PR DESCRIPTION
## Summary
Added search parameter to /customers end point using `name` and `email` query parameters while still being able to search for all customers.

## Changes Made
- Modified `getAllCustomers()` controller method to accept optional `name` and `email` query parameters
- Modified `searchCustomers()` service method to accept parameters
- Added support for individual field searches and combined field searches
- Removed /customers/search endpoint

## API Usage
The `/customers` endpoint now supports:
- `GET /customers` - Returns all customers (unchanged)
- `GET /customers?name=justin` - Search by name only
- `GET /customers?email=gmail.com` - Search by email only  
- `GET /customers?name=justin&email=gmail.com` - Search by both name and email

